### PR TITLE
feat: support generic functions

### DIFF
--- a/macros/src/fn_datatype.rs
+++ b/macros/src/fn_datatype.rs
@@ -3,7 +3,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{
     parse::{Parse, ParseStream},
-    Ident, Path, Token,
+    Ident, Path, PathArguments, Token,
 };
 
 pub struct FnDatatypeInput {
@@ -32,6 +32,7 @@ pub fn proc_macro(
         .expect("Function path is empty!");
 
     last.ident = format_fn_wrapper(&last.ident.clone());
+    last.arguments = PathArguments::None;
 
     let fn_signature = quote!(#specta_fn_macro!(@signature));
     let fn_name = quote!(#specta_fn_macro!(@name));


### PR DESCRIPTION
Example:

```rust
#[tauri::command]
#[specta::specta]
fn dev<R: tauri::Runtime>(window: Window<R>) {
    if !window.is_devtools_open() {
        window.open_devtools()
    }
}

...

// The code below will get a 'generic arguments in macro path' error after 'dev'.
tauri_specta::ts::export(tauri_specta::collate_types![dev::<R>],  "...").unwrap();
```

Reason:

It affects code like this

```rust
quote!(#specta_fn_macro!(@signature))
```

to generate wrong code 

```rust
__specta__fn__dev::<R>!(...)
```