### PR TITLE
Allow doc comments

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -13,7 +13,7 @@ mod fn_datatype;
 mod specta;
 mod r#type;
 
-#[proc_macro_derive(Type, attributes(specta, serde, doc))]
+#[proc_macro_derive(Type, attributes(specta, serde))]
 pub fn derive_type(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     r#type::derive(input, "specta".into()).unwrap_or_else(|err| err.into_compile_error().into())
 }
@@ -21,7 +21,7 @@ pub fn derive_type(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 /// This macro is exposed from rspc as a wrapper around [Type] with a correct import path.
 /// This is exposed from here so rspc doesn't need a macro package for 4 lines of code.
 #[doc(hidden)]
-#[proc_macro_derive(RSPCType, attributes(specta, serde, doc))]
+#[proc_macro_derive(RSPCType, attributes(specta, serde))]
 pub fn derive_rspc_type(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     r#type::derive(input, "rspc::internal::specta".into())
         .unwrap_or_else(|err| err.into_compile_error().into())


### PR DESCRIPTION
Currently when trying to use a doc comment in an enum with `#[derive(specta::Type)]`, it fails with the following compile error:
```
error[E0659]: `doc` is ambiguous
  --> editor/src/messages/layout/utility_types/misc.rs:27:2
   |
27 |     /// The color swatch for the working colors and a flip and reset button found at the bottom of the tool shelf.
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ambiguous name
   |
   = note: ambiguous because of a name conflict with a builtin attribute
   = note: `doc` could refer to a built-in attribute
note: `doc` could also refer to the derive helper attribute defined here
  --> editor/src/messages/layout/utility_types/misc.rs:4:83
   |
4  | #[derive(PartialEq, Clone, Debug, Hash, Eq, Copy, Serialize, Deserialize, specta::Type)]
   |                                                                                   ^^^^
```