### PR TITLE
fix: generate BigInt type as `bigint`

### DIFF
--- a/src/lang/ts/mod.rs
+++ b/src/lang/ts/mod.rs
@@ -656,4 +656,4 @@ const STRING: &str = "string";
 const BOOLEAN: &str = "boolean";
 const NULL: &str = "null";
 const NEVER: &str = "never";
-const BIGINT: &str = "BigInt";
+const BIGINT: &str = "bigint";

--- a/tests/bigints.rs
+++ b/tests/bigints.rs
@@ -69,7 +69,7 @@ fn test_bigint_types() {
 
     for_bigint_types!(T -> |name| assert_eq!(specta::ts::inline::<T>(&ExportConfig::new().bigint(BigIntExportBehavior::String)), Ok("string".into())));
     for_bigint_types!(T -> |name| assert_eq!(specta::ts::inline::<T>(&ExportConfig::new().bigint(BigIntExportBehavior::Number)), Ok("number".into())));
-    for_bigint_types!(T -> |name| assert_eq!(specta::ts::inline::<T>(&ExportConfig::new().bigint(BigIntExportBehavior::BigInt)), Ok("BigInt".into())));
+    for_bigint_types!(T -> |name| assert_eq!(specta::ts::inline::<T>(&ExportConfig::new().bigint(BigIntExportBehavior::BigInt)), Ok("bigint".into())));
 
     // Check error messages are working correctly -> These tests second for `ExportPath` which is why they are so comprehensive
     assert_eq!(


### PR DESCRIPTION
The type of BigInt in Typescript is `bigint` (not `BigInt`). `bigint` is the type and `BigInt` is the constructor. 

Here is the typescript docs for reference: https://typescriptlang.org/docs/handbook/release-notes/typescript-3-2.html#bigint

> BigInt support in TypeScript introduces a new primitive type called the `bigint` (all lowercase). You can get a `bigint` by calling the `BigInt()` function or by writing out a BigInt literal by adding an `n` to the end of any integer numeric literal

```ts
let foo: bigint = BigInt(100); // the BigInt function
let bar: bigint = 100n; // a BigInt literal

function fibonacci(n: bigint) {
...
}
```

I need this to stop VSCode to complain :) 