### PR TITLE
feat: Adds optional `ulid` Type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,8 @@ tauri = ["dep:tauri"]
 #! External types
 ## [uuid](https://docs.rs/uuid) crate
 uuid = ["dep:uuid"]
+## [uuid](https://docs.rs/ulid) crate
+ulid = ["dep:ulid"]
 ## [chrono](https://docs.rs/chrono) crate
 chrono = ["dep:chrono"]
 ## [time](https://docs.rs/time) crate
@@ -106,6 +108,7 @@ serde = { version = "1.0.183", optional = true, default-features = false, featur
 serde_json = { version = "1.0.104", optional = true, default-features = false, features = ["std"] }
 serde_yaml = { version = "0.9.25", optional = true, default-features = false, features = [] }
 toml = { version = "0.7.6", optional = true, default-features = false }
+ulid = { version = "1.1.0", optional = true, default-features = false, features = [] }
 uuid = { version = "1.4.1", optional = true, default-features = false, features = [] }
 chrono = { version = "0.4.26", optional = true, default-features = false, features = ["clock"] }
 time = { version = "0.3.25", optional = true, default-features = false, features = [] }

--- a/src/docs.md
+++ b/src/docs.md
@@ -60,6 +60,7 @@ Compatability
 
 External types
 
+- `ulid` - [ulid](https://docs.rs/ulid) crate
 - `uuid` - [uuid](https://docs.rs/uuid) crate
 - `chrono` - [chrono](https://docs.rs/chrono) crate
 - `time` - [time](https://docs.rs/time) crate

--- a/src/type/impls.rs
+++ b/src/type/impls.rs
@@ -446,6 +446,9 @@ const _: () = {
     }
 };
 
+#[cfg(feature = "ulid")]
+impl_as!(ulid::Ulid as String);
+
 #[cfg(feature = "uuid")]
 impl_as!(
     uuid::Uuid as String

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -22,6 +22,9 @@ pub mod ts;
 mod ts_rs;
 mod ty_override;
 
+#[cfg(all(feature = "ulid", feature = "typescript"))]
+mod ulid;
+
 #[test]
 fn test_compile_errors() {
     let t = trybuild::TestCases::new();

--- a/tests/ulid.rs
+++ b/tests/ulid.rs
@@ -1,0 +1,13 @@
+use specta::Type;
+
+use crate::ts::assert_ts;
+
+#[derive(Type)]
+#[specta(export = false)]
+struct ExampleId(pub ulid::Ulid);
+
+#[test]
+fn ulid() {
+    assert_ts!(ulid::Ulid, "string");
+    assert_ts!(ExampleId, "string");
+}


### PR DESCRIPTION
https://docs.rs/ulid a neat alternative to UUIDs.
`u128` displayed as Base32 for example: `01HCHXGPMZZSMTCB58CQCWKP7Z`

Testing: `cargo test --features ulid,typescript --test integration_tests -- ulid::ulid`