### PR TITLE
internal: Specta Test Macro

### DIFF
--- a/tests/remote_impls.rs
+++ b/tests/remote_impls.rs
@@ -1,5 +1,4 @@
-#[test]
-#[cfg(feature = "glam")]
+#[specta_macros::stest(feature = "glam")]
 fn typescript_types_glam() {
     use crate::ts::assert_ts;
 


### PR DESCRIPTION
+ Cleanup unit tests & make them work without the Typescript feature enabled.