### PR TITLE
Merge d4hines/main

### DIFF
--- a/src/lang/ts/mod.rs
+++ b/src/lang/ts/mod.rs
@@ -14,7 +14,6 @@ pub use export_config::*;
 use reserved_terms::*;
 
 use crate::{
-    functions::FunctionDataType,
     internal::{skip_fields, skip_fields_named, NonSkipField},
     *,
 };
@@ -96,7 +95,12 @@ pub fn export_named_datatype(
 /// If your function requires a function body you can copy this function into your own codebase.
 ///
 /// Eg. `function name();`
-pub fn export_function_header(dt: FunctionDataType, config: &ExportConfig) -> Result<String> {
+#[cfg(feature = "functions")]
+#[cfg_attr(docsrs, doc(cfg(feature = "functions")))]
+pub fn export_function_header(
+    dt: crate::functions::FunctionDataType,
+    config: &ExportConfig,
+) -> Result<String> {
     let type_map = TypeMap::default();
 
     let mut s = config


### PR DESCRIPTION
Bug reproduction:
```rust
use specta::{ts, Type};

#[derive(Type)]

pub struct MyStruct {
    foo: String,
    bar: String,
}

#[derive(Type)]
#[serde(tag = "type")]
pub enum MyEnum {
    A(Option<MyStruct>),
    B,
}

fn main() {
    assert_eq!(
        ts::export::<MyEnum>(&Default::default()).unwrap(),
        "export type MyEnum = ({ type: \"A\" } & (MyStruct | null)) | { type: \"B\" }".to_string()
    );
    println!("ok!");
}
```
Copied from [here](https://github.com/d4hines/specta-serde-bug/blob/master/src/main.rs).

Edit: After more digging I actually don't understand the bug here. The type is the above example will throw a Serde error but even so the Typescript is still valid and the "resolved" type matches Serde so i'm going to close this.