### PR TITLE
Bumped Bevy version to 0.13.2 and added `bevy_input`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,8 +98,8 @@ tokio = ["dep:tokio"]
 url = ["dep:url"]
 ## [either](https://docs.rs/either) crate
 either = ["dep:either"]
-# [bevy_ecs](https://docs.rs/bevy_ecs) crate
-bevy_ecs = ["dep:bevy_ecs"]
+# [bevy_ecs](https://docs.rs/bevy_ecs) and [bevy_input](https://docs.rs/bevy_input) crate
+bevy = ["dep:bevy_ecs", "dep:bevy_input"]
 
 [dependencies]
 specta-macros = { version = "=2.0.0-rc.9", path = "./macros" }
@@ -125,7 +125,8 @@ glam = { version = "0.25", optional = true, default-features = false, features =
 tokio = { version = "1.30", optional = true, default-features = false, features = ["sync"] }
 url = { version = "2.4.0", optional = true, default-features = false }
 either = { version = "1.9.0", optional = true, default-features = false }
-bevy_ecs = { version = "0.13.0", optional = true, default-features = false }
+bevy_ecs = { version = "0.13.2", optional = true, default-features = false }
+bevy_input = { version = "0.13.2", optional = true, default-features = false }
 thiserror = "1.0.44"
 paste = "1.0.14"
 ctor = { version = "0.2.4", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,9 +98,9 @@ tokio = ["dep:tokio"]
 url = ["dep:url"]
 ## [either](https://docs.rs/either) crate
 either = ["dep:either"]
-# [bevy_ecs](https://docs.rs/bevy_ecs)
+# [bevy_ecs](https://docs.rs/bevy_ecs) crate
 bevy_ecs = ["dep:bevy_ecs"]
-# [bevy_input](https://docs.rs/bevy_input)
+# [bevy_input](https://docs.rs/bevy_input) crate
 bevy_input = ["dep:bevy_input", "dep:bevy_ecs", "dep:glam"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,8 +98,10 @@ tokio = ["dep:tokio"]
 url = ["dep:url"]
 ## [either](https://docs.rs/either) crate
 either = ["dep:either"]
-# [bevy_ecs](https://docs.rs/bevy_ecs) and [bevy_input](https://docs.rs/bevy_input) crate
-bevy = ["dep:bevy_ecs", "dep:bevy_input"]
+# [bevy_ecs](https://docs.rs/bevy_ecs)
+bevy_ecs = ["dep:bevy_ecs"]
+# [bevy_input](https://docs.rs/bevy_input)
+bevy_input = ["dep:bevy_input", "dep:bevy_ecs", "dep:glam"]
 
 [dependencies]
 specta-macros = { version = "=2.0.0-rc.9", path = "./macros" }

--- a/src/type/impls.rs
+++ b/src/type/impls.rs
@@ -762,9 +762,7 @@ const _: () = {
     #[specta(remote = bevy_input::ButtonState, crate = crate, export = false)]
     #[allow(dead_code)]
     enum ButtonState {
-        /// The button is pressed.
         Pressed,
-        /// The button is not pressed.
         Released,
     }
 
@@ -772,13 +770,9 @@ const _: () = {
     #[specta(remote = bevy_input::keyboard::KeyboardInput, crate = crate, export = false)]
     #[allow(dead_code)]
     struct KeyboardInput {
-        /// The physical key code of the key.
         pub key_code: bevy_input::keyboard::KeyCode,
-        /// The logical key of the input
         pub logical_key: bevy_input::keyboard::Key,
-        /// The press state of the key.
         pub state: bevy_input::ButtonState,
-        /// Window that received the input.
         pub window: bevy_ecs::entity::Entity,
     }
 
@@ -792,11 +786,8 @@ const _: () = {
     #[specta(remote = bevy_input::mouse::MouseButtonInput, crate = crate, export = false)]
     #[allow(dead_code)]
     pub struct MouseButtonInput {
-        /// The mouse button assigned to the event.
         pub button: bevy_input::mouse::MouseButton,
-        /// The pressed state of the button.
         pub state: bevy_input::ButtonState,
-        /// Window that received the input.
         pub window: bevy_ecs::entity::Entity,
     }
 
@@ -804,17 +795,11 @@ const _: () = {
     #[specta(remote = bevy_input::mouse::MouseButton, crate = crate, export = false)]
     #[allow(dead_code)]
     pub enum MouseButton {
-        /// The left mouse button.
         Left,
-        /// The right mouse button.
         Right,
-        /// The middle mouse button.
         Middle,
-        /// The back mouse button.
         Back,
-        /// The forward mouse button.
         Forward,
-        /// Another mouse button with the associated number.
         Other(u16),
     }
 
@@ -822,13 +807,9 @@ const _: () = {
     #[specta(remote = bevy_input::mouse::MouseWheel, crate = crate, export = false)]
     #[allow(dead_code)]
     pub struct MouseWheel {
-        /// The mouse scroll unit.
         pub unit: bevy_input::mouse::MouseScrollUnit,
-        /// The horizontal scroll value.
         pub x: f32,
-        /// The vertical scroll value.
         pub y: f32,
-        /// Window that received the input.
         pub window: bevy_ecs::entity::Entity,
     }
 
@@ -836,15 +817,7 @@ const _: () = {
     #[specta(remote = bevy_input::mouse::MouseScrollUnit, crate = crate, export = false)]
     #[allow(dead_code)]
     pub enum MouseScrollUnit {
-        /// The line scroll unit.
-        ///
-        /// The delta of the associated [`MouseWheel`] event corresponds
-        /// to the amount of lines or rows to scroll.
         Line,
-        /// The pixel scroll unit.
-        ///
-        /// The delta of the associated [`MouseWheel`] event corresponds
-        /// to the amount of pixels to scroll.
         Pixel,
     }
 
@@ -852,7 +825,6 @@ const _: () = {
     #[specta(remote = bevy_input::mouse::MouseMotion, crate = crate, export = false)]
     #[allow(dead_code)]
     pub struct MouseMotion {
-        /// The change in the position of the pointing device since the last event was sent.
         pub delta: glam::Vec2,
     }
 };

--- a/src/type/impls.rs
+++ b/src/type/impls.rs
@@ -751,10 +751,108 @@ impl<L: Type, R: Type> Type for either::Either<L, R> {
     }
 }
 
-#[cfg(feature = "bevy_ecs")]
+#[cfg(feature = "bevy")]
 const _: () = {
     #[derive(Type)]
     #[specta(rename = "Entity", remote = bevy_ecs::entity::Entity, crate = crate, export = false)]
     #[allow(dead_code)]
     struct EntityDef(u64);
+
+    #[derive(Type)]
+    #[specta(remote = bevy_input::ButtonState, crate = crate, export = false)]
+    #[allow(dead_code)]
+    enum ButtonState {
+        /// The button is pressed.
+        Pressed,
+        /// The button is not pressed.
+        Released,
+    }
+
+    #[derive(Type)]
+    #[specta(remote = bevy_input::keyboard::KeyboardInput, crate = crate, export = false)]
+    #[allow(dead_code)]
+    struct KeyboardInput {
+        /// The physical key code of the key.
+        pub key_code: bevy_input::keyboard::KeyCode,
+        /// The logical key of the input
+        pub logical_key: bevy_input::keyboard::Key,
+        /// The press state of the key.
+        pub state: bevy_input::ButtonState,
+        /// Window that received the input.
+        pub window: bevy_ecs::entity::Entity,
+    }
+
+    // Reduced KeyCode and Key to String to avoid redefining a quite large enum (for now)
+    impl_as!(
+        bevy_input::keyboard::KeyCode as String
+        bevy_input::keyboard::Key as String
+    );
+
+    #[derive(Type)]
+    #[specta(remote = bevy_input::mouse::MouseButtonInput, crate = crate, export = false)]
+    #[allow(dead_code)]
+    pub struct MouseButtonInput {
+        /// The mouse button assigned to the event.
+        pub button: bevy_input::mouse::MouseButton,
+        /// The pressed state of the button.
+        pub state: bevy_input::ButtonState,
+        /// Window that received the input.
+        pub window: bevy_ecs::entity::Entity,
+    }
+
+    #[derive(Type)]
+    #[specta(remote = bevy_input::mouse::MouseButton, crate = crate, export = false)]
+    #[allow(dead_code)]
+    pub enum MouseButton {
+        /// The left mouse button.
+        Left,
+        /// The right mouse button.
+        Right,
+        /// The middle mouse button.
+        Middle,
+        /// The back mouse button.
+        Back,
+        /// The forward mouse button.
+        Forward,
+        /// Another mouse button with the associated number.
+        Other(u16),
+    }
+
+    #[derive(Type)]
+    #[specta(remote = bevy_input::mouse::MouseWheel, crate = crate, export = false)]
+    #[allow(dead_code)]
+    pub struct MouseWheel {
+        /// The mouse scroll unit.
+        pub unit: bevy_input::mouse::MouseScrollUnit,
+        /// The horizontal scroll value.
+        pub x: f32,
+        /// The vertical scroll value.
+        pub y: f32,
+        /// Window that received the input.
+        pub window: bevy_ecs::entity::Entity,
+    }
+
+    #[derive(Type)]
+    #[specta(remote = bevy_input::mouse::MouseScrollUnit, crate = crate, export = false)]
+    #[allow(dead_code)]
+    pub enum MouseScrollUnit {
+        /// The line scroll unit.
+        ///
+        /// The delta of the associated [`MouseWheel`] event corresponds
+        /// to the amount of lines or rows to scroll.
+        Line,
+        /// The pixel scroll unit.
+        ///
+        /// The delta of the associated [`MouseWheel`] event corresponds
+        /// to the amount of pixels to scroll.
+        Pixel,
+    }
+
+    #[derive(Type)]
+    #[specta(remote = bevy_input::mouse::MouseMotion, crate = crate, export = false)]
+    #[allow(dead_code)]
+    pub struct MouseMotion {
+        /// The change in the position of the pointing device since the last event was sent.
+        pub delta: glam::Vec2,
+    }
 };

--- a/src/type/impls.rs
+++ b/src/type/impls.rs
@@ -751,13 +751,16 @@ impl<L: Type, R: Type> Type for either::Either<L, R> {
     }
 }
 
-#[cfg(feature = "bevy")]
+#[cfg(feature = "bevy_ecs")]
 const _: () = {
     #[derive(Type)]
     #[specta(rename = "Entity", remote = bevy_ecs::entity::Entity, crate = crate, export = false)]
     #[allow(dead_code)]
     struct EntityDef(u64);
+};
 
+#[cfg(feature = "bevy_input")]
+const _: () = {
     #[derive(Type)]
     #[specta(remote = bevy_input::ButtonState, crate = crate, export = false)]
     #[allow(dead_code)]


### PR DESCRIPTION
In this MR I bumped the Bevy version and added `bevy_input` feature . Should I keep `bevy_input` separate or combine into single `bevy` feature?