### PR TITLE
Handle raw function arguments property

### DIFF
--- a/tests/functions.rs
+++ b/tests/functions.rs
@@ -90,6 +90,9 @@ mod test {
         pub fn nested() {}
     }
 
+    #[specta]
+    fn raw(r#type: i32) {}
+
     // TODO: Finish fixing these
 
     #[test]
@@ -318,6 +321,12 @@ mod test {
             assert_eq!(def.args.len(), 0);
             assert_eq!(def.result, None);
             assert_eq!(def.docs, Cow::Borrowed(" Testing Doc Comment"));
+        }
+
+        {
+            let mut type_map = &mut specta::TypeMap::default();
+            let def: function::FunctionDataType = specta::fn_datatype!(type_map; raw);
+            assert_eq!(def.args[0].0, "type");
         }
     }
 }

--- a/tests/macro/compile_error.stderr
+++ b/tests/macro/compile_error.stderr
@@ -83,14 +83,14 @@ error[E0277]: the trait bound `UnitExternal: specta::Flatten` is not satisfied
    |           ^^^^^^^^^^^^ the trait `specta::Flatten` is not implemented for `UnitExternal`
    |
    = help: the following other types implement trait `specta::Flatten`:
-             toml::map::Map<K, V>
-             FlattenExternal
-             toml_datetime::datetime::Datetime
-             FlattenUntagged
-             FlattenInternal
+             Arc<T>
+             BTreeMap<K, V>
              Box<T>
-             serde_json::map::Map<K, V>
-             HashMap<K, V>
+             Cell<T>
+             Duration
+             FlattenExternal
+             FlattenInternal
+             FlattenUntagged
            and $N others
 note: required by a bound in `_::<impl specta::Type for FlattenExternal>::inline::validate_flatten`
   --> tests/macro/compile_error.rs:29:10
@@ -106,14 +106,14 @@ error[E0277]: the trait bound `UnnamedMultiExternal: specta::Flatten` is not sat
    |                    ^^^^^^^^^^^^^^^^^^^^ the trait `specta::Flatten` is not implemented for `UnnamedMultiExternal`
    |
    = help: the following other types implement trait `specta::Flatten`:
-             toml::map::Map<K, V>
-             FlattenExternal
-             toml_datetime::datetime::Datetime
-             FlattenUntagged
-             FlattenInternal
+             Arc<T>
+             BTreeMap<K, V>
              Box<T>
-             serde_json::map::Map<K, V>
-             HashMap<K, V>
+             Cell<T>
+             Duration
+             FlattenExternal
+             FlattenInternal
+             FlattenUntagged
            and $N others
 note: required by a bound in `_::<impl specta::Type for FlattenExternal>::inline::validate_flatten`
   --> tests/macro/compile_error.rs:29:10
@@ -129,14 +129,14 @@ error[E0277]: the trait bound `UnnamedUntagged: specta::Flatten` is not satisfie
    |              ^^^^^^^^^^^^^^^ the trait `specta::Flatten` is not implemented for `UnnamedUntagged`
    |
    = help: the following other types implement trait `specta::Flatten`:
-             toml::map::Map<K, V>
-             FlattenExternal
-             toml_datetime::datetime::Datetime
-             FlattenUntagged
-             FlattenInternal
+             Arc<T>
+             BTreeMap<K, V>
              Box<T>
-             serde_json::map::Map<K, V>
-             HashMap<K, V>
+             Cell<T>
+             Duration
+             FlattenExternal
+             FlattenInternal
+             FlattenUntagged
            and $N others
 note: required by a bound in `_::<impl specta::Type for FlattenUntagged>::inline::validate_flatten`
   --> tests/macro/compile_error.rs:49:10
@@ -152,14 +152,14 @@ error[E0277]: the trait bound `UnnamedMultiUntagged: specta::Flatten` is not sat
    |                    ^^^^^^^^^^^^^^^^^^^^ the trait `specta::Flatten` is not implemented for `UnnamedMultiUntagged`
    |
    = help: the following other types implement trait `specta::Flatten`:
-             toml::map::Map<K, V>
-             FlattenExternal
-             toml_datetime::datetime::Datetime
-             FlattenUntagged
-             FlattenInternal
+             Arc<T>
+             BTreeMap<K, V>
              Box<T>
-             serde_json::map::Map<K, V>
-             HashMap<K, V>
+             Cell<T>
+             Duration
+             FlattenExternal
+             FlattenInternal
+             FlattenUntagged
            and $N others
 note: required by a bound in `_::<impl specta::Type for FlattenUntagged>::inline::validate_flatten`
   --> tests/macro/compile_error.rs:49:10
@@ -175,14 +175,14 @@ error[E0277]: the trait bound `UnnamedInternal: specta::Flatten` is not satisfie
    |              ^^^^^^^^^^^^^^^ the trait `specta::Flatten` is not implemented for `UnnamedInternal`
    |
    = help: the following other types implement trait `specta::Flatten`:
-             toml::map::Map<K, V>
-             FlattenExternal
-             toml_datetime::datetime::Datetime
-             FlattenUntagged
-             FlattenInternal
+             Arc<T>
+             BTreeMap<K, V>
              Box<T>
-             serde_json::map::Map<K, V>
-             HashMap<K, V>
+             Cell<T>
+             Duration
+             FlattenExternal
+             FlattenInternal
+             FlattenUntagged
            and $N others
 note: required by a bound in `_::<impl specta::Type for FlattenInternal>::inline::validate_flatten`
   --> tests/macro/compile_error.rs:67:10

--- a/tests/ts.rs
+++ b/tests/ts.rs
@@ -293,9 +293,9 @@ fn typescript_types() {
         ExportError::InvalidName(
             NamedLocation::Type,
             #[cfg(not(windows))]
-            ExportPath::new_unsafe("tests/ts.rs:619:10"),
+            ExportPath::new_unsafe("tests/ts.rs:630:10"),
             #[cfg(windows)]
-            ExportPath::new_unsafe("tests\ts.rs:619:10"),
+            ExportPath::new_unsafe("tests\ts.rs:630:10"),
             r#"@odata.context"#.to_string()
         )
     );
@@ -305,9 +305,9 @@ fn typescript_types() {
         ExportError::InvalidName(
             NamedLocation::Type,
             #[cfg(not(windows))]
-            ExportPath::new_unsafe("tests/ts.rs:623:10"),
+            ExportPath::new_unsafe("tests/ts.rs:634:10"),
             #[cfg(windows)]
-            ExportPath::new_unsafe("tests\ts.rs:623:10"),
+            ExportPath::new_unsafe("tests\ts.rs:634:10"),
             r#"@odata.context"#.to_string()
         )
     );


### PR DESCRIPTION
Function arguments starting with `r#` should have it stripped from them