### PR TITLE
Add additional time types

### DIFF
--- a/specta/src/type/legacy_impls.rs
+++ b/specta/src/type/legacy_impls.rs
@@ -256,6 +256,8 @@ impl_as!(
     time::OffsetDateTime as String
     time::Date as String
     time::Time as String
+    time::Duration as String
+    time::Weekday as String
 );
 
 #[cfg(feature = "bigdecimal")]


### PR DESCRIPTION
Duration and Weekday are also serialized as strings, just like OffsetDateTime, Time, etc.